### PR TITLE
fix bugs about G1

### DIFF
--- a/include/Algorithm/DesignAspect/Generic.hpp
+++ b/include/Algorithm/DesignAspect/Generic.hpp
@@ -172,15 +172,14 @@ void StreamClustering<W, D, O, R>::RunOffline(DataSinkPtr ptr) {
     }
     onlineCenters.push_back(centroid);
   }
-  r->Run(param, onlineCenters, ptr);
   for (int i = 0; i < outliers_.size(); ++i) {
     auto centroid = GenericFactory::New<Point>(param.dim, i, 1, 0);
     for (int j = 0; j < param.dim; j++) {
       centroid->feature[j] = outliers_[i]->cf.ls[j] / outliers_[i]->cf.num;
     }
-    centroid->outlier = true;
-    ptr->put(centroid);
+    onlineCenters.push_back(centroid);
   }
+  r->Run(param, onlineCenters, ptr);
   ref_timer.Tock();
   sum_timer.Tock();
 }

--- a/include/Algorithm/OfflineRefinement/OfflineRefinement.hpp
+++ b/include/Algorithm/OfflineRefinement/OfflineRefinement.hpp
@@ -26,7 +26,10 @@ public:
   NoRefinement(const StreamClusteringParam &param) {}
   void Run(StreamClusteringParam &param, const std::vector<PointPtr> &input,
            DataSinkPtr sinkPtr) {
+    int i = 0;
     for (auto p : input) {
+      p->setClusteringCenter(i);
+      i++;
       sinkPtr->put(p->copy());
     }
   }

--- a/src/Algorithm/OfflineRefinement/KMeans.cpp
+++ b/src/Algorithm/OfflineRefinement/KMeans.cpp
@@ -286,7 +286,7 @@ void SESAME::KMeans::Run(SESAME::StreamClusteringParam &param,
                          vector<PointPtr> &onlineCenters,
                          SESAME::DataSinkPtr sinkPtr) {
   srand(param.seed);
-  if(onlineCenters.size() <= param.k){
+  if(onlineCenters.size() <= param.k or param.k < 2){
     int i = 0;
     for(auto el : onlineCenters) {
      el->setClusteringCenter(i++);

--- a/src/Utils/BenchmarkUtils.cpp
+++ b/src/Utils/BenchmarkUtils.cpp
@@ -492,21 +492,21 @@ BenchmarkResultPtr BenchmarkUtils::runBenchmark(param_t &cmd_params,
   std::vector<SESAME::PointPtr> predicts;
   // the output clusterID start from 0
   if (cmd_params.run_eval) {
-    if (cmd_params.run_offline)
-    {
-      SESAME::UtilityFunctions::groupByCentersWithOffline(
-          inputs, results, predicts, cmd_params.dim);
-      // 使用offline的算法不管是否detect
-      // outlier输出都是一样，如果detect则clusteringIndex = 0代表outlier
-      // clustering center
-    }
-    else
-    {
+//    if (cmd_params.run_offline)
+//    {
+//      SESAME::UtilityFunctions::groupByCentersWithOffline(
+//          inputs, results, predicts, cmd_params.dim);
+//      // 使用offline的算法不管是否detect
+//      // outlier输出都是一样，如果detect则clusteringIndex = 0代表outlier
+//      // clustering center
+//    }
+//    else
+//    {
       // the output is the clustering center so we need to help every input data
       // find its nearest center
       SESAME::UtilityFunctions::groupByCenters(inputs, results, predicts,
                                                cmd_params.dim);
-    }
+//    }
   }
 
   cmd_params.num_res = results.size();

--- a/src/Utils/UtilityFunctions.cpp
+++ b/src/Utils/UtilityFunctions.cpp
@@ -84,35 +84,35 @@ std::shared_ptr<std::barrier<>>
 SESAME::UtilityFunctions::createBarrier(int count) {
   return std::make_shared<std::barrier<>>(count);
 }
-void SESAME::UtilityFunctions::groupByCenters(
-    const std::vector<PointPtr> &input, const std::vector<PointPtr> &centers,
-    std::vector<PointPtr> &output, int dim) {
-  auto n = input.size();
-  for (int i = 0; i < n; i++)
-    output.push_back(input[i]->copy());
-#pragma omp parallel for
-  for (int i = 0; i < n; i++) {
-    auto min = DBL_MAX;
-    int selectCenterIndex = -1;
-    bool outlier = false;
-    for (int j = 0; j < centers.size(); j++) {
-      double dis = output[i]->L2Dist(centers[j]);
-      if (min > dis) {
-        selectCenterIndex = j;
-        min = dis;
-        if(centers[j]->getOutlier()){
-          outlier = true;
-        } else {
-          outlier = false;
-        }
-      }
-    }
-    output[i]->setOutlier(outlier);
-    output[i]->setClusteringCenter(selectCenterIndex);
-  }
-}
+//void SESAME::UtilityFunctions::groupByCenters(
+//    const std::vector<PointPtr> &input, const std::vector<PointPtr> &centers,
+//    std::vector<PointPtr> &output, int dim) {
+//  auto n = input.size();
+//  for (int i = 0; i < n; i++)
+//    output.push_back(input[i]->copy());
+//#pragma omp parallel for
+//  for (int i = 0; i < n; i++) {
+//    auto min = DBL_MAX;
+//    int selectCenterIndex = -1;
+//    bool outlier = false;
+//    for (int j = 0; j < centers.size(); j++) {
+//      double dis = output[i]->L2Dist(centers[j]);
+//      if (min > dis) {
+//        selectCenterIndex = j;
+//        min = dis;
+//        if(centers[j]->getOutlier()){
+//          outlier = true;
+//        } else {
+//          outlier = false;
+//        }
+//      }
+//    }
+//    output[i]->setOutlier(outlier);
+//    output[i]->setClusteringCenter(selectCenterIndex);
+//  }
+//}
 
-void SESAME::UtilityFunctions::groupByCentersWithOffline(
+void SESAME::UtilityFunctions::groupByCenters(
     const std::vector<PointPtr> &input, const std::vector<PointPtr> &centers,
     std::vector<PointPtr> &output, int dim) {
   auto n = input.size();
@@ -128,10 +128,10 @@ void SESAME::UtilityFunctions::groupByCentersWithOffline(
         min = dis;
       }
     }
-    if(output[i]->getClusteringCenter() == -1){
-      output[i]->setOutlier(true);
-    } else {
-      output[i]->setOutlier(false);
-    }
+//    if(output[i]->getClusteringCenter() == -1){
+//      output[i]->setOutlier(true);
+//    } else {
+//      output[i]->setOutlier(false);
+//    }
   }
 }


### PR DESCRIPTION
Three problems:

1. We run offline clustering(such as kmeans) only on real centers and set the belonging id(start from 0) to every center before sinking. However, when we start sinking the outlier centers, we forget setting the id but just set outlier(bool) true.
2. For KMeans, when k <2, error occurs.
3. For evaluation, it is required that the clustering id we set before start from 0, but we set the id of outlier center -1 in groupByCentersWithOffline function and forget setting id for outlier centers in groupByCenters function.

So I include both real and outlier centers for running offline clustering(such as kmeans), and thus it is no longer required to additionally set id for outlier centers. They all start from 0. Besides, after this change, the old groupByCenters can be erased and we can use the same function to group the result centers no matter with or withour offline clusteirng.